### PR TITLE
implement prediction pipeline with json serializer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests with coverage
         run: |
-          pytest -k "(unit or test_basic_commands) and not slow" --cov --cov-report term-missing
+          pytest -k "not slow" --ignore=tests/shell/test_debug_configs.py --ignore=tests/shell/test_sweeps.py --cov --cov-report term-missing

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -26,16 +26,17 @@ name: "default"
 # or the url to huggingface hub where the taskmodule and model was pushed to
 model_name_or_path: pie/example-ner-spanclf-conll03
 
-# specify the taskmodule
+# specify the PyTorch-IE pipeline
 pipeline:
   _target_: pytorch_ie.auto.AutoPipeline.from_pretrained
   predict_field: entities
+  show_progress_bar: true
 
 # to override model weights with content of a checkpoint
 ckpt_path: null
 
 # which split from the loaded dataset will be used. If the dataset does contain
-# only one, this is chosen by default.
+# only one, it is chosen by default when set to null.
 dataset_split: test
 
 # this will be passed to the serializer

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -38,5 +38,8 @@ ckpt_path: null
 # which split from the loaded dataset will be used
 dataset_split: test
 
-# this will be passed to the serializer
+# this will be passed to the serializer as "path" parameter
 out_path: predictions/${name}/${dataset_split}/${now:%Y-%m-%d_%H-%M-%S}.jsonl
+
+# if set, the final config including resolved paths etc. will be written to this location
+config_out_path: ${out_path}.config.yaml

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -35,8 +35,7 @@ pipeline:
 # to override model weights with content of a checkpoint
 ckpt_path: null
 
-# which split from the loaded dataset will be used. If the dataset does contain
-# only one, it is chosen by default when set to null.
+# which split from the loaded dataset will be used
 dataset_split: test
 
 # this will be passed to the serializer

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -3,7 +3,7 @@
 # specify here default prediction configuration
 defaults:
   - _self_
-  - dataset: ???
+  - dataset: conll2003
   - serializer: json
 
   # enable color logging
@@ -24,23 +24,23 @@ name: "default"
 
 # this should be the value of save_dir from the train config
 # or the url to huggingface hub where the taskmodule and model was pushed to
-model_name_or_path: ???
+model_name_or_path: pie/example-ner-spanclf-conll03
 
 # specify the taskmodule
 pipeline:
   _target_: pytorch_ie.auto.AutoPipeline.from_pretrained
-  predict_field: ???
+  predict_field: entities
 
 # to override model weights with content of a checkpoint
 ckpt_path: null
 
 # which split from the loaded dataset will be used. If the dataset does contain
 # only one, this is chosen by default.
-dataset_split: null
+dataset_split: test
 
 # if true, remove all annotations from the annotation field with name "predict_field"
 # before executing the pipeline
 remove_annotations: true
 
 # this will be passed to the serializer
-out_path: ???
+out_path: predictions/conll2003_test.jsonl

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -38,9 +38,5 @@ ckpt_path: null
 # only one, this is chosen by default.
 dataset_split: test
 
-# if true, remove all annotations from the annotation field with name "predict_field"
-# before executing the pipeline
-remove_annotations: true
-
 # this will be passed to the serializer
 out_path: predictions/${name}/${dataset_split}/${now:%Y-%m-%d_%H-%M-%S}.jsonl

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -1,0 +1,46 @@
+# @package _global_
+
+# specify here default prediction configuration
+defaults:
+  - _self_
+  - dataset: ???
+  - serializer: json
+
+  # enable color logging
+  - override hydra/hydra_logging: colorlog
+  - override hydra/job_logging: colorlog
+
+original_work_dir: ${hydra:runtime.cwd}
+
+data_dir: ${original_work_dir}/data/
+
+print_config: True
+
+ignore_warnings: True
+
+seed: null
+
+name: "default"
+
+# this should be the value of save_dir from the train config
+# or the url to huggingface hub where the taskmodule and model was pushed to
+model_name_or_path: ???
+
+# specify the taskmodule
+pipeline:
+  _target_: pytorch_ie.auto.AutoPipeline.from_pretrained
+  predict_field: ???
+
+# to override model weights with content of a checkpoint
+ckpt_path: null
+
+# which split from the loaded dataset will be used. If the dataset does contain
+# only one, this is chosen by default.
+dataset_split: null
+
+# if true, remove all annotations from the annotation field with name "predict_field"
+# before executing the pipeline
+remove_annotations: true
+
+# this will be passed to the serializer
+out_path: ???

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -43,4 +43,4 @@ dataset_split: test
 remove_annotations: true
 
 # this will be passed to the serializer
-out_path: predictions/conll2003_test.jsonl
+out_path: predictions/${name}/${dataset_split}/${now:%Y-%m-%d_%H-%M-%S}.jsonl

--- a/configs/serializer/json.yaml
+++ b/configs/serializer/json.yaml
@@ -1,0 +1,3 @@
+_target_: src.serializer.JsonSerializer
+as_lines: true
+# indent: 2  # makes only sense if as_lines = false

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,26 @@
+import dotenv
+import hydra
+from omegaconf import DictConfig
+
+# load environment variables from `.env` file if it exists
+# recursively searches for `.env` in all folders starting from work dir
+dotenv.load_dotenv(override=True)
+
+
+@hydra.main(config_path="configs/", config_name="predict.yaml")
+def main(config: DictConfig):
+
+    # Imports can be nested inside @hydra.main to optimize tab completion
+    # https://github.com/facebookresearch/hydra/issues/934
+    from src import utils
+    from src.prediction_pipeline import predict
+
+    # Applies optional utilities
+    utils.extras(config)
+
+    # Predict
+    return predict(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -11,12 +11,6 @@ from pytorch_lightning import seed_everything
 from src import utils
 
 
-def clear_annotation_field(doc: Document, field_name: str) -> Document:
-    doc[field_name].clear()
-    # return the document to allow usage with dataset.map
-    return doc
-
-
 log = utils.get_logger(__name__)
 
 
@@ -73,13 +67,6 @@ def predict(config: DictConfig) -> None:
 
     # select the dataset split for prediction
     dataset_predict = dataset[config.dataset_split]
-
-    # annotations with the same name as the ones to predict can be deleted before adding the new annotations
-    if config.remove_annotations:
-
-        dataset_predict = dataset_predict.map(
-            clear_annotation_field, fn_kwargs=dict(field_name=config.pipeline.predict_field)
-        )
 
     log.info("Starting inference!")
     dataset_with_predictions = pipeline(dataset_predict, inplace=False)

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -47,7 +47,9 @@ def predict(config: DictConfig) -> None:
     dataset: Dict[str, Dataset] = hydra.utils.instantiate(config.dataset)
 
     # Init pytorch-ie pipeline
-    log.info(f"Instantiating pipeline <{config.pipeline._target_}> from {config.model_name_or_path}")
+    log.info(
+        f"Instantiating pipeline <{config.pipeline._target_}> from {config.model_name_or_path}"
+    )
     pipeline: Pipeline = hydra.utils.instantiate(
         config.pipeline, pretrained_model_name_or_path=config.model_name_or_path
     )

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -56,14 +56,6 @@ def predict(config: DictConfig) -> None:
             pipeline.device
         )
 
-    # if no dataset split is defined, but only one is available, we take this one
-    if config.dataset_split is None:
-        if len(dataset) > 1:
-            raise Exception(
-                f"dataset_split is not defined, but dataset has multiple splits: {list(dataset.keys())}"
-            )
-        config.dataset_split = list(dataset.keys())[0]
-
     # select the dataset split for prediction
     dataset_predict = dataset[config.dataset_split]
 

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -1,0 +1,105 @@
+import os.path
+from typing import Callable, Dict, Sequence
+
+import hydra
+from omegaconf import DictConfig
+from pytorch_ie.core import Document
+from pytorch_ie.data import Dataset
+from pytorch_ie.pipeline import Pipeline
+from pytorch_lightning import seed_everything
+
+from src import utils
+
+
+def clear_annotation_field(doc: Document, field_name: str) -> Document:
+    doc[field_name].clear()
+    # return the document to allow usage with dataset.map
+    return doc
+
+
+def move_predictions_to_annotations(doc: Document, field_name: str) -> Document:
+    for annotation in doc[field_name].predictions:
+        doc[field_name].append(annotation)
+    doc[field_name].predictions._annotations = []
+    return doc
+
+
+log = utils.get_logger(__name__)
+
+
+def predict(config: DictConfig) -> None:
+    """Contains minimal example of the prediction pipeline.
+    Uses a pretrained model to annotate documents from a dataset and serializes them.
+
+    Args:
+        config (DictConfig): Configuration composed by Hydra.
+
+    Returns:
+        None
+    """
+
+    # Set seed for random number generators in pytorch, numpy and python.random
+    if config.get("seed"):
+        seed_everything(config.seed, workers=True)
+
+    # Convert to absolute path
+    absolute_path = hydra.utils.to_absolute_path(config.model_name_or_path)
+    # If the converted path exists locally, use it.
+    # Otherwise, model_name_or_path may point to a resource at Huggingface model hub.
+    if os.path.exists(absolute_path):
+        config.model_name_or_path = absolute_path
+
+    # Init pytorch-ie dataset
+    log.info(f"Instantiating dataset <{config.dataset._target_}>")
+    dataset: Dict[str, Dataset] = hydra.utils.instantiate(config.dataset)
+
+    # Init pytorch-ie pipeline
+    log.info(f"Instantiating pipeline <{config.pipeline._target_}>")
+    pipeline: Pipeline = hydra.utils.instantiate(
+        config.pipeline, pretrained_model_name_or_path=config.model_name_or_path
+    )
+
+    # Per default, the model is loaded with .from_pretrained() which already loads the weights.
+    # However, ckpt_path can be used to load different weights from any checkpoint.
+    if config.ckpt_path is not None:
+        # Convert relative ckpt path to absolute path if necessary
+        config.ckpt_path = hydra.utils.to_absolute_path(config.ckpt_path)
+        pipeline.model.load_from_checkpoint(checkpoint_path=config.ckpt_path)
+
+    # if no dataset split is defined, but only one is available, we take this one
+    if config.dataset_split is None:
+        if len(dataset) > 1:
+            raise Exception(
+                f"dataset_split is not defined, but dataset has multiple splits: {list(dataset.keys())}"
+            )
+        config.dataset_split = list(dataset.keys())[0]
+
+    # select the dataset split for prediction
+    dataset_predict = dataset[config.dataset_split]
+
+    # annotations with the same name as the ones to predict can be deleted before adding the new annotations
+    if config.remove_annotations:
+
+        dataset_predict = dataset_predict.map(
+            clear_annotation_field, fn_kwargs=dict(field_name=config.pipeline.predict_field)
+        )
+
+    log.info("Starting inference!")
+    dataset_with_predictions = pipeline(dataset_predict, inplace=False)
+
+    # promote predictions to annotations (this may be required for serialization)
+    dataset_with_predictions = [
+        move_predictions_to_annotations(doc, field_name=config.pipeline.predict_field)
+        for doc in dataset_with_predictions
+    ]
+
+    # Convert to absolute path
+    config.out_path = hydra.utils.to_absolute_path(config.out_path)
+
+    # Init the serializer
+    log.info(f"Instantiating serializer <{config.serializer._target_}>")
+    serializer: Callable[[Sequence[Document]], None] = hydra.utils.instantiate(
+        config.serializer, path=config.out_path
+    )
+    # serialize the documents
+    serializer(dataset_with_predictions)

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -64,7 +64,9 @@ def predict(config: DictConfig) -> None:
     if config.ckpt_path is not None:
         # Convert relative ckpt path to absolute path if necessary
         config.ckpt_path = hydra.utils.to_absolute_path(config.ckpt_path)
-        pipeline.model.load_from_checkpoint(checkpoint_path=config.ckpt_path)
+        pipeline.model = pipeline.model.load_from_checkpoint(checkpoint_path=config.ckpt_path).to(
+            pipeline.device
+        )
 
     # if no dataset split is defined, but only one is available, we take this one
     if config.dataset_split is None:

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -17,13 +17,6 @@ def clear_annotation_field(doc: Document, field_name: str) -> Document:
     return doc
 
 
-def move_predictions_to_annotations(doc: Document, field_name: str) -> Document:
-    for annotation in doc[field_name].predictions:
-        doc[field_name].append(annotation)
-    doc[field_name].predictions._annotations = []
-    return doc
-
-
 log = utils.get_logger(__name__)
 
 
@@ -88,12 +81,6 @@ def predict(config: DictConfig) -> None:
 
     log.info("Starting inference!")
     dataset_with_predictions = pipeline(dataset_predict, inplace=False)
-
-    # promote predictions to annotations (this may be required for serialization)
-    dataset_with_predictions = [
-        move_predictions_to_annotations(doc, field_name=config.pipeline.predict_field)
-        for doc in dataset_with_predictions
-    ]
 
     # Convert to absolute path
     config.out_path = hydra.utils.to_absolute_path(config.out_path)

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -10,7 +10,6 @@ from pytorch_lightning import seed_everything
 
 from src import utils
 
-
 log = utils.get_logger(__name__)
 
 

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -47,7 +47,7 @@ def predict(config: DictConfig) -> None:
     dataset: Dict[str, Dataset] = hydra.utils.instantiate(config.dataset)
 
     # Init pytorch-ie pipeline
-    log.info(f"Instantiating pipeline <{config.pipeline._target_}>")
+    log.info(f"Instantiating pipeline <{config.pipeline._target_}> from {config.model_name_or_path}")
     pipeline: Pipeline = hydra.utils.instantiate(
         config.pipeline, pretrained_model_name_or_path=config.model_name_or_path
     )

--- a/src/prediction_pipeline.py
+++ b/src/prediction_pipeline.py
@@ -2,7 +2,7 @@ import os.path
 from typing import Callable, Dict, Sequence
 
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from pytorch_ie.core import Document
 from pytorch_ie.data import Dataset
 from pytorch_ie.pipeline import Pipeline
@@ -72,3 +72,8 @@ def predict(config: DictConfig) -> None:
     )
     # serialize the documents
     serializer(dataset_with_predictions)
+
+    # serialize config with resolved paths
+    if config.get("config_out_path"):
+        config.config_out_path = hydra.utils.to_absolute_path(config.config_out_path)
+        OmegaConf.save(config=config, f=config.config_out_path)

--- a/src/serializer/__init__.py
+++ b/src/serializer/__init__.py
@@ -1,0 +1,1 @@
+from .json import JsonSerializer

--- a/src/serializer/json.py
+++ b/src/serializer/json.py
@@ -1,0 +1,31 @@
+import json
+import os
+from typing import Sequence
+
+from pytorch_ie.core import Document
+
+from src import utils
+
+log = utils.get_logger(__name__)
+
+
+class JsonSerializer:
+    def __init__(self, path: str, as_lines: bool = True, **kwargs):
+        self.path = path
+        self.as_lines = as_lines
+        self.kwargs = kwargs
+
+    def __call__(self, documents: Sequence[Document]):
+
+        realpath = os.path.realpath(self.path)
+        log.info(f'serialize documents to "{realpath}" ...')
+        dir_path = os.path.dirname(realpath)
+        os.makedirs(dir_path, exist_ok=True)
+
+        if self.as_lines:
+            with open(self.path, "w") as f:
+                for doc in documents:
+                    f.write(json.dumps(doc.asdict(), **self.kwargs) + "\n")
+        else:
+            with open(self.path, "w") as f:
+                json.dump([doc.asdict() for doc in documents], fp=f, **self.kwargs)

--- a/tests/shell/test_basic_commands.py
+++ b/tests/shell/test_basic_commands.py
@@ -22,12 +22,10 @@ def test_evaluation_single_batch():
     run_command(command)
 
 
-@pytest.mark.slow
-def test_prediction(tmp_path):
-    """Test the prediction script."""
-    # TODO: use fast_dev_run when available and remove "slow"
+def test_prediction_fast_dev_run(tmp_path):
+    """Test the prediction script with two input encodings (pipeline.fast_dev_run)."""
     out_path = tmp_path / "predictions"
-    command = ["predict.py", f"out_path={out_path}"]
+    command = ["predict.py", f"out_path={out_path}", "++pipeline.fast_dev_run=true"]
     run_command(command)
     assert os.path.exists(out_path)
 

--- a/tests/shell/test_basic_commands.py
+++ b/tests/shell/test_basic_commands.py
@@ -1,3 +1,5 @@
+import os.path
+
 import pytest
 
 from tests.helpers.run_command import run_command
@@ -18,6 +20,16 @@ def test_evaluation_single_batch():
     """Test the test script with a single batch."""
     command = ["test.py", "++trainer.limit_test_batches=1"]
     run_command(command)
+
+
+@pytest.mark.slow
+def test_prediction(tmp_path):
+    """Test the prediction script."""
+    # TODO: use fast_dev_run when available and remove "slow"
+    out_path = tmp_path / "predictions"
+    command = ["predict.py", f"out_path={out_path}"]
+    run_command(command)
+    assert os.path.exists(out_path)
 
 
 @pytest.mark.skip(reason="this takes too much time")

--- a/tests/unit/serializer/test_json.py
+++ b/tests/unit/serializer/test_json.py
@@ -1,0 +1,45 @@
+import json
+from dataclasses import dataclass
+
+from pytorch_ie.annotations import LabeledSpan, BinaryRelation
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextDocument
+
+from src.serializer import JsonSerializer
+
+
+@dataclass
+class ExampleDocument(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+def test_serialize_json(tmp_path):
+    document = ExampleDocument(
+        "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
+    )
+    entities = [
+        LabeledSpan(start=65, end=75, label="PER"),
+        LabeledSpan(start=96, end=100, label="ORG"),
+        LabeledSpan(start=126, end=134, label="ORG"),
+    ]
+    for ent in entities:
+        document.entities.append(ent)
+
+    relations = [
+        BinaryRelation(head=entities[0], tail=entities[1], label="per:employee_of"),
+        BinaryRelation(head=entities[0], tail=entities[2], label="per:employee_of"),
+    ]
+
+    # add relations as predictions
+    for rel in relations:
+        document.relations.predictions.append(rel)
+
+    path = str(tmp_path / "out.jsonl")
+    serializer = JsonSerializer(path=path)
+
+    serializer(documents=[document])
+
+    loaded = [json.loads(l) for l in open(path).readlines()]
+    document_loaded = ExampleDocument.fromdict(loaded[0])
+    assert document_loaded == document

--- a/tests/unit/serializer/test_json.py
+++ b/tests/unit/serializer/test_json.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 
-from pytorch_ie.annotations import LabeledSpan, BinaryRelation
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
 from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.documents import TextDocument
 


### PR DESCRIPTION
This implements a very simply prediction pipeline in analogy to the test and train pipelines. It can be called like:

```
python predict.py
```

where this happens behind the scene:
```
python predict.py \
dataset=conll2003 \
dataset_split=test \
model_name_or_path=pie/example-ner-spanclf-conll03 \
pipeline.predict_field=entities \
out_path=prediction/conll2003_test.jsonl
```

To execute on the gpu and set a batch size, add these parameters:
```
+pipeline.device=0 +pipeline.batch_size=64
``` 

This requires: #26 

EDIT: This also fixes the GitHub tests action (previously, unit tests were not executed).