### PR TITLE
Improve wandb logging

### DIFF
--- a/configs/experiment/conll2003.yaml
+++ b/configs/experiment/conll2003.yaml
@@ -30,6 +30,9 @@ datamodule:
 
 logger:
   wandb:
-    project: pie-example-conll2003
-    tags: ["conll2003", "transformer_token_classification"]
+    name: "first-run"
+    tags:
+      - dataset=conll2003
+      - model=transformer_token_classification
+      - task=ner
 # save_dir: models/${name}/debug

--- a/configs/logger/wandb.yaml
+++ b/configs/logger/wandb.yaml
@@ -2,8 +2,8 @@
 
 wandb:
   _target_: pytorch_lightning.loggers.wandb.WandbLogger
-  project: "template-tests"
-  name: ${name}
+  project: ${replace:${name},/,-}
+  #name: ""  # set a name for the run
   save_dir: "."
   offline: False # set True to store all logs only locally
   id: null # pass correct id to resume experiment!

--- a/train.py
+++ b/train.py
@@ -1,10 +1,13 @@
 import dotenv
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 # load environment variables from `.env` file if it exists
 # recursively searches for `.env` in all folders starting from work dir
 dotenv.load_dotenv(override=True)
+
+# register replace resolver (used to replace "/" with "-" in names to use them as wandb project names)
+OmegaConf.register_new_resolver("replace", lambda s, x, y: s.replace(x, y))
 
 
 @hydra.main(config_path="configs/", config_name="train.yaml")


### PR DESCRIPTION
Some tweaks to improve the default setup. Notably, the wandb project name will be created from the `$name`. Previously, it was just used to define the name of the run (i.e. to set `wandb.name`).