### PR TITLE
add src to pythonpath in train / test / predict scripts

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,3 +1,6 @@
+import sys
+from os.path import dirname, join, realpath
+
 import dotenv
 import hydra
 from omegaconf import DictConfig
@@ -17,6 +20,10 @@ def main(config: DictConfig):
 
     # Applies optional utilities
     utils.extras(config)
+
+    # add src to system path to allow its usage with configs
+    root_path = realpath(dirname(__file__))
+    sys.path.append(join(root_path, "src"))
 
     # Predict
     return predict(config)

--- a/test.py
+++ b/test.py
@@ -1,3 +1,6 @@
+import sys
+from os.path import dirname, join, realpath
+
 import dotenv
 import hydra
 from omegaconf import DictConfig
@@ -17,6 +20,10 @@ def main(config: DictConfig):
 
     # Applies optional utilities
     utils.extras(config)
+
+    # add src to system path to allow its usage with configs
+    root_path = realpath(dirname(__file__))
+    sys.path.append(join(root_path, "src"))
 
     # Evaluate model
     return test(config)

--- a/train.py
+++ b/train.py
@@ -1,3 +1,6 @@
+import sys
+from os.path import dirname, join, realpath
+
 import dotenv
 import hydra
 from omegaconf import DictConfig, OmegaConf
@@ -20,6 +23,10 @@ def main(config: DictConfig):
 
     # Applies optional utilities
     utils.extras(config)
+
+    # add src to system path to allow its usage with configs
+    root_path = realpath(dirname(__file__))
+    sys.path.append(join(root_path, "src"))
 
     # Train model
     return train(config)


### PR DESCRIPTION
otherwise it is not easily possible to use modules from `src` within configs