### PR TITLE
gitignore data, logs, and models only as root elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,9 +141,9 @@ dmypy.json
 
 # Lightning-Hydra-Template
 configs/local/default.yaml
-data/
-logs/
-models/
+/data/
+/logs/
+/models/
 wandb/
 .env
 .autoenv


### PR DESCRIPTION
Before this, files in e.g. `src/models/` were ignored which is not intended.