### PR TITLE
fix aim logger config

### DIFF
--- a/configs/logger/aim.yaml
+++ b/configs/logger/aim.yaml
@@ -10,3 +10,4 @@ aim:
   experiment: ${replace:${name},/,-}
   train_metric_prefix: train/
   val_metric_prefix: val/
+  test_metric_prefix: test/


### PR DESCRIPTION
add missing entry `test_metric_prefix: test/`