### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pytorch-ie>=0.12.0,<0.13
 
 # downgrade because of https://github.com/ChristophAlt/pytorch-ie/issues/239
 datasets==2.7.1
+# downgrade because otherwise LightningLoggerBase can not be imported
+pytorch-lightning==1.8.6
 
 # --------- hydra --------- #
 hydra-core>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # --------- pytorch-ie --------- #
 pytorch-ie>=0.12.0,<0.13
 
+# downgrade because of https://github.com/ChristophAlt/pytorch-ie/issues/239
+datasets==2.7.1
+
 # --------- hydra --------- #
 hydra-core>=1.2.0
 hydra-colorlog>=1.2.0


### PR DESCRIPTION
* downgrade `datasets` to `2.7.1` because of https://github.com/ChristophAlt/pytorch-ie/issues/239
* upgrade `pytorch-lightning` to `1.8.6` because of
```
ERROR tests/test_eval.py - ImportError: cannot import name 'LightningLoggerBase' from 'pytorch_lightning.loggers' (/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/pytorch_lightning/loggers/__init__.py)
ERROR tests/test_eval.py
ERROR tests/test_predict.py - ImportError: cannot import name 'LightningLoggerBase' from 'pytorch_lightning.loggers' (/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/pytorch_lightning/loggers/__init__.py)
ERROR tests/test_predict.py
ERROR tests/test_train.py - ImportError: cannot import name 'LightningLoggerBase' from 'pytorch_lightning.loggers' (/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/pytorch_lightning/loggers/__init__.py)
ERROR tests/test_train.py
```