### PR TITLE
Improve example env file and add quickstart instruction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,8 @@
 # .env is loaded by train.py automatically
 # hydra allows you to reference variables in .yaml configs with special syntax: ${oc.env:MY_VAR}
 
-MY_VAR="/home/user/my/system/path"
+# example, uncomment and adapt for your needs!
+# MY_VAR="/home/user/my/system/path"
+
+# disabling tokenizer parallelism is recommended since we already use dataloader parallelism
+TOKENIZERS_PARALLELISM=false

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ pip install -r requirements.txt
 # [OPTIONAL] symlink log directories and the default model directory to
 # "$HOME/experiments/my-project" since they can grow a lot
 bash setup_symlinks.sh $HOME/experiments/my-project
+
+# [OPTIONAL] set any environment variables by creating an .env file
+# 1. copy the provided example file:
+cp .env.example .env
+# 2. edit the .env file for your needs!
 ```
 
 Template contains example with CONLL2003 Named Entity Recognition.<br>


### PR DESCRIPTION
* add `TOKENIZERS_PARALLELISM=false` to the example env file `.env.example`
* add optional instruction to the quickstart section in the readme for setting up `.env` file  