### PR TITLE
dataset utils

### DIFF
--- a/configs/dataset/_create_validation_split.yaml
+++ b/configs/dataset/_create_validation_split.yaml
@@ -1,0 +1,10 @@
+create_validation_split:
+  _processor_: src.utils.dataset.add_test_split
+  # take 10% of the train split as the validation split
+  test_size: 0.1
+  # set a fixed seed to make the splitting reproducible
+  seed: 12345
+  source_split: train
+  # datasets.create_test_split() names the new split "test", but we want to use it as "validation" split
+  rename_result_splits:
+    test: validation

--- a/configs/dataset/_select_n.yaml
+++ b/configs/dataset/_select_n.yaml
@@ -1,0 +1,11 @@
+select_n:
+  _processor_: src.utils.dataset.select
+  split: train
+  # take all data per default
+  stop: null
+
+select_n_test:
+  _processor_: src.utils.dataset.select
+  split: test
+  # take all data per default
+  stop: null

--- a/configs/dataset/conll2003_base.yaml
+++ b/configs/dataset/conll2003_base.yaml
@@ -1,0 +1,7 @@
+# This config on its own does nothing more than conll2003.yaml. However, it can be easily combined with further
+# preprocessing configs, see conll2003_select_n.yaml for an example.
+
+_target_: src.utils.dataset.process_dataset
+input:
+  _target_: datasets.load_dataset
+  path: pie/conll2003

--- a/configs/dataset/conll2003_select_n.yaml
+++ b/configs/dataset/conll2003_select_n.yaml
@@ -1,0 +1,13 @@
+# Simple preprocessing pipeline that loads conll2003 and allows to select a subset of documents. Uses all
+# documents per default.
+
+# Usage:
+# Just use dataset=conll2003_select_n and set any "stop" parameter,
+# e.g. dataset.select_n.stop=5 to take only 5 train documents. See _select_n.yaml for further options.
+
+defaults:
+  - example_base
+  - _select_n
+  # for datasets, that do not yet have a validation split, just uncomment the following line
+  # to create one from the train split (see _create_validation_split.yaml for further options)
+  # - _create_validation_split

--- a/configs/dataset/conll2003_select_n.yaml
+++ b/configs/dataset/conll2003_select_n.yaml
@@ -6,7 +6,7 @@
 # e.g. dataset.select_n.stop=5 to take only 5 train documents. See _select_n.yaml for further options.
 
 defaults:
-  - example_base
+  - conll2003_base
   - _select_n
   # for datasets, that do not yet have a validation split, just uncomment the following line
   # to create one from the train split (see _create_validation_split.yaml for further options)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,10 @@
+from src.utils.dataset import (
+    add_test_split,
+    convert_documents,
+    process_dataset,
+    rename_splits,
+    select,
+)
 from src.utils.pylogger import get_pylogger
 from src.utils.rich_utils import enforce_tags, print_config_tree
 from src.utils.utils import (

--- a/src/utils/dataset.py
+++ b/src/utils/dataset.py
@@ -1,0 +1,115 @@
+import json
+from copy import copy
+from typing import Callable, Dict, Optional, Type, TypeVar, Union
+
+from hydra._internal.instantiate._instantiate2 import _resolve_target, instantiate
+from pytorch_ie import Dataset
+from pytorch_ie.core import Document
+from typing_extensions import SupportsIndex
+
+import datasets
+from src.utils.pylogger import get_pylogger
+
+logger = get_pylogger(__name__)
+
+
+def process_dataset(input: datasets.DatasetDict, **processors) -> datasets.DatasetDict:
+    result = input
+    for processor_name, processor_config in processors.items():
+        logger.info(f"process dataset: {processor_name}")
+        config = copy(processor_config)
+        # rename key "_processor_" to "_target_"
+        config["_target_"] = config.pop("_processor_")
+        config["dataset"] = result
+        tmp_result = instantiate(config=config, _convert_="partial")
+        if tmp_result is not None:
+            result = tmp_result
+        else:
+            logger.warning(f"dataset processor {processor_name} did not return a result")
+    return result
+
+
+D = TypeVar("D", bound=Document)
+
+
+def convert_documents(
+    dataset: datasets.DatasetDict,
+    function: Optional[Union[Callable, str]] = None,
+    result_type: Optional[Union[str, Type[D]]] = None,
+    **kwargs,
+) -> datasets.DatasetDict:
+    if function is not None:
+        func = _resolve_target(function, full_key="")
+    else:
+
+        def identity(x):
+            return x
+
+        func = identity
+    map_kwargs = dict(function=func, fn_kwargs=kwargs)
+    if result_type is not None:
+        result_type = _resolve_target(result_type, full_key="")
+        map_kwargs["result_document_type"] = result_type
+    dataset = type(dataset)({k: v.map(**map_kwargs) for k, v in dataset.items()})
+
+    return dataset
+
+
+def select(
+    dataset: datasets.DatasetDict,
+    split: str,
+    start: Optional[SupportsIndex] = None,
+    stop: Optional[SupportsIndex] = None,
+    step: Optional[SupportsIndex] = None,
+    **kwargs,
+) -> datasets.DatasetDict:
+    if stop is not None:
+        range_args = [stop]
+        if start is not None:
+            range_args = [start] + range_args
+        if step is not None:
+            range_args = range_args + [step]
+        kwargs["indices"] = range(*range_args)
+    pie_split = dataset[split]
+    if "indices" in kwargs:
+        dataset[split] = Dataset.from_hf_dataset(
+            dataset=pie_split.select(**kwargs), document_type=dataset[split].document_type
+        )
+    else:
+        if len(kwargs) > 0:
+            logger.warning(
+                f"arguments for dataset.select() available, but they do not contain 'indices' which is required, "
+                f"so we do not call select. provided arguments: \n{json.dumps(kwargs, indent=2)}"
+            )
+    return dataset
+
+
+def rename_splits(
+    dataset: datasets.DatasetDict,
+    mapping: Optional[Dict[str, str]] = None,
+) -> datasets.DatasetDict:
+    if mapping is None:
+        mapping = {}
+    result = datasets.DatasetDict(
+        {mapping.get(name, name): data for name, data in dataset.items()}
+    )
+    return result
+
+
+def add_test_split(
+    dataset: datasets.DatasetDict,
+    source_split: str = "train",
+    rename_result_splits: Optional[Dict[str, str]] = None,
+    **kwargs,
+) -> datasets.DatasetDict:
+    split_result_hf = dataset[source_split].train_test_split(**kwargs)
+    split_result = datasets.DatasetDict(
+        {
+            name: Dataset.from_hf_dataset(ds, document_type=dataset[source_split].document_type)
+            for name, ds in split_result_hf.items()
+        }
+    )
+    split_result = rename_splits(dataset=split_result, mapping=rename_result_splits)
+    res = copy(dataset)
+    res.update(split_result)
+    return res


### PR DESCRIPTION
implements the following functions in the `utils` package:
 - `process_dataset`
 - `convert_documents`
 - `add_test_split`
 - `rename_splits`
 - `select`

and example dataset configs that contain respective documentation:
 - `_create_validation_split`
 - `_select_n`
 - `conll2003_base`
 - `conll2003_select_n`