### PR TITLE
update isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,9 @@ repos:
       - id: black
         args: [--line-length, "99"]
 
-  # python import sorting x
+  # python import sorting
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: black
         args: [--line-length, "99"]
 
-  # python import sorting
+  # python import sorting x
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
CI is broken by version v1.5.0 of `poetry-core`, see [here](https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff). Updating `isort` to version 5.12.0 fixes this.