### PR TITLE
Fix double encode

### DIFF
--- a/configs/datamodule/default.yaml
+++ b/configs/datamodule/default.yaml
@@ -1,6 +1,7 @@
-_target_: pytorch_ie.data.datamodules.datamodule.DataModule
+_target_: src.datamodules.PieDataModule
 
 # some defaults
 batch_size: 32
 num_workers: 0
 pin_memory: False
+show_progress_for_encode: true

--- a/src/datamodules/__init__.py
+++ b/src/datamodules/__init__.py
@@ -1,0 +1,1 @@
+from .datamodule import PieDataModule

--- a/src/datamodules/datamodule.py
+++ b/src/datamodules/datamodule.py
@@ -1,0 +1,129 @@
+from typing import Any, Dict, Generic, Optional, Sequence, TypeVar, Union
+
+from pytorch_ie.core import Document
+from pytorch_ie.core.taskmodule import (
+    IterableTaskEncodingDataset,
+    TaskEncoding,
+    TaskEncodingDataset,
+    TaskModule,
+)
+from pytorch_lightning import LightningDataModule
+from torch.utils.data import DataLoader
+
+DocumentType = TypeVar("DocumentType", bound=Document)
+InputEncoding = TypeVar("InputEncoding")
+TargetEncoding = TypeVar("TargetEncoding")
+
+
+class PieDataModule(LightningDataModule, Generic[DocumentType, InputEncoding, TargetEncoding]):
+    """A simple LightningDataModule for PIE document datasets.
+
+    A DataModule implements 5 key methods:
+        - prepare_data (things to do on 1 GPU/TPU, not on every GPU/TPU in distributed mode)
+        - setup (things to do on every accelerator in distributed mode)
+        - train_dataloader (the training dataloader)
+        - val_dataloader (the validation dataloader(s))
+        - test_dataloader (the test dataloader(s))
+
+    This allows you to share a full dataset without explaining how to download,
+    split, transform and process the data.
+
+    Read the docs:
+        https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html
+    """
+
+    def __init__(
+        self,
+        taskmodule: TaskModule[DocumentType, InputEncoding, TargetEncoding, Any, Any, Any],
+        dataset: Dict[str, Sequence[DocumentType]],
+        data_config_path: Optional[str] = None,
+        train_split: Optional[str] = "train",
+        val_split: Optional[str] = "validation",
+        test_split: Optional[str] = "test",
+        show_progress_for_encode: bool = False,
+        **dataloader_kwargs,
+    ):
+        super().__init__()
+
+        self.taskmodule = taskmodule
+        self.config_path = data_config_path
+        self.dataset = dataset
+        self.train_split = train_split
+        self.val_split = val_split
+        self.test_split = test_split
+        self.show_progress_for_encode = show_progress_for_encode
+        self.dataloader_kwargs = dataloader_kwargs
+
+        self._data: Dict[
+            str,
+            Union[
+                TaskEncodingDataset[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
+                IterableTaskEncodingDataset[
+                    TaskEncoding[DocumentType, InputEncoding, TargetEncoding]
+                ],
+            ],
+        ] = {}
+
+    @property
+    def num_train(self) -> int:
+        if self.train_split is None:
+            raise ValueError("no train_split assigned")
+        data_train = self._data.get(self.train_split, None)
+        if data_train is None:
+            raise ValueError("can not get train size if setup() was not yet called")
+        if isinstance(data_train, IterableTaskEncodingDataset):
+            raise TypeError("IterableTaskEncodingDataset has no length")
+        return len(data_train)
+
+    def prepare_data(self):
+
+        for split in [self.train_split, self.val_split, self.test_split]:
+            if split is None or split not in self.dataset:
+                continue
+            task_encoding_dataset = self.taskmodule.encode(
+                self.dataset[split],
+                encode_target=True,
+                as_dataset=True,
+                show_progress=self.show_progress_for_encode,
+            )
+            if not isinstance(
+                task_encoding_dataset, (TaskEncodingDataset, IterableTaskEncodingDataset)
+            ):
+                raise TypeError(
+                    f"taskmodule.encode did not return a (Iterable)TaskEncodingDataset, but: {type(task_encoding_dataset)}"
+                )
+            self._data[split] = task_encoding_dataset
+
+    def data_split(
+        self, split: Optional[str] = None
+    ) -> Union[
+        TaskEncodingDataset[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
+        IterableTaskEncodingDataset[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
+    ]:
+        if split is None or split not in self._data:
+            raise ValueError(f"data for split={split} not available")
+        return self._data[split]
+
+    def train_dataloader(self):
+        return DataLoader(
+            dataset=self.data_split(self.train_split),
+            collate_fn=self.taskmodule.collate,
+            shuffle=True,
+            **self.dataloader_kwargs,
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            dataset=self.data_split(self.val_split),
+            collate_fn=self.taskmodule.collate,
+            shuffle=False,
+            **self.dataloader_kwargs,
+        )
+
+    def test_dataloader(self):
+        return DataLoader(
+            dataset=self.data_split(self.test_split),
+            collate_fn=self.taskmodule.collate,
+            shuffle=False,
+            **self.dataloader_kwargs,
+        )

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -79,7 +79,6 @@ def evaluate(cfg: DictConfig) -> Tuple[dict, dict]:
     datamodule: DataModule = hydra.utils.instantiate(
         cfg.datamodule, dataset=dataset, taskmodule=taskmodule, _convert_="partial"
     )
-    datamodule.setup(stage="test")
 
     # Init pytorch-ie model
     log.info(f"Instantiating model <{cfg.model._target_}>")

--- a/src/train.py
+++ b/src/train.py
@@ -40,11 +40,11 @@ import pytorch_lightning as pl
 from omegaconf import DictConfig
 from pytorch_ie import DatasetDict
 from pytorch_ie.core import PyTorchIEModel, TaskModule
-from pytorch_ie.data.datamodules.datamodule import DataModule
 from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.loggers import Logger
 
 from src import utils
+from src.datamodules import PieDataModule
 
 log = utils.get_pylogger(__name__)
 
@@ -78,11 +78,11 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
 
     # Init pytorch-ie datamodule
     log.info(f"Instantiating datamodule <{cfg.datamodule._target_}>")
-    datamodule: DataModule = hydra.utils.instantiate(
+    datamodule: PieDataModule = hydra.utils.instantiate(
         cfg.datamodule, dataset=dataset, taskmodule=taskmodule, _convert_="partial"
     )
-    # This calls taskmodule.prepare() on the train split.
-    datamodule.setup(stage="fit")
+    # Use the train dataset split to prepare the taskmodule
+    taskmodule.prepare(dataset["train"])
 
     # Init pytorch-ie model
     log.info(f"Instantiating model <{cfg.model._target_}>")


### PR DESCRIPTION
The data is encoded twice: when calling datamodule.setup() and in the datamodule hook when starting the training (similar for evaluation). This fixes that by creating a datamodule with just prepare_data() which does the encoding. taskmodule.prepare() is called directly from the train script.