### PR TITLE
Improve logger paths

### DIFF
--- a/configs/logger/aim.yaml
+++ b/configs/logger/aim.yaml
@@ -8,7 +8,7 @@
 aim:
   _target_: aim.pytorch_lightning.AimLogger
   repo: ${paths.log_dir}/logger/aim/.aim
-  experiment: ${replace:${name},/,-}
+  experiment: ${replace:${name},/,-}-${pipeline_type}
   train_metric_prefix: train/
   val_metric_prefix: val/
   test_metric_prefix: test/

--- a/configs/logger/csv.yaml
+++ b/configs/logger/csv.yaml
@@ -2,6 +2,6 @@
 
 csv:
   _target_: pytorch_lightning.loggers.csv_logs.CSVLogger
-  save_dir: "${paths.output_dir}"
-  name: "csv/"
+  save_dir: ${paths.log_dir}/logger/csv/
+  name: ${replace:${name},/,-}-${pipeline_type}
   prefix: ""

--- a/configs/logger/mlflow.yaml
+++ b/configs/logger/mlflow.yaml
@@ -2,7 +2,7 @@
 
 mlflow:
   _target_: pytorch_lightning.loggers.mlflow.MLFlowLogger
-  # experiment_name: ""
+  experiment_name: ${replace:${name},/,-}-${pipeline_type}
   # run_name: ""
   tracking_uri: ${paths.log_dir}/logger/mlflow/mlruns # run `mlflow ui` command inside the `logs/mlflow/` dir to open the UI
   tags: null

--- a/configs/logger/mlflow.yaml
+++ b/configs/logger/mlflow.yaml
@@ -4,7 +4,7 @@ mlflow:
   _target_: pytorch_lightning.loggers.mlflow.MLFlowLogger
   # experiment_name: ""
   # run_name: ""
-  tracking_uri: ${paths.log_dir}/logger/mlflow/mlruns # run `mlflow ui` command inside the `logs/logger/mlflow` dir to open the UI
+  tracking_uri: ${paths.log_dir}/logger/mlflow/mlruns # run `mlflow ui` command inside the `logs/mlflow/` dir to open the UI
   tags: null
   # save_dir: "./mlruns"
   prefix: ""

--- a/configs/logger/wandb.yaml
+++ b/configs/logger/wandb.yaml
@@ -7,7 +7,7 @@ wandb:
   offline: False
   id: null # pass correct id to resume experiment!
   anonymous: null # enable anonymous logging
-  project: ${replace:${name},/,-}
+  project: ${replace:${name},/,-}-${pipeline_type}
   log_model: False # upload lightning ckpts
   prefix: "" # a string to put at the beginning of metric keys
   # entity: "" # set to name of your wandb team


### PR DESCRIPTION
This PR modifies the logger configs in the following way:
 - for csv : align the `save_dir` with the respective values of the aim and mlflow loggers, i.e. `${paths.log_dir}/logger/csv/`
 - for csv, aim, mlflow, and wandb: append the value of pipeline_type, i.e. `training`, `evaluation`, or `prediction`, to the experiment / project name
 - for csv, and mlflow:  align the (experiment_)name with the respective value of aim, i.e. `${replace:${name},/,-}-${pipeline_type}`

