### PR TITLE
Fix saving the best model after training

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -157,7 +157,7 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
     if best_ckpt_path != "":
         log.info(f"Best ckpt path: {best_ckpt_path}")
 
-    if not cfg.trainer.get("fast_dev_run") and cfg.get("train"):
+    if not cfg.trainer.get("fast_dev_run"):
         if cfg.model_save_dir is not None:
             if best_ckpt_path == "":
                 log.warning("Best ckpt not found! Using current weights for saving...")

--- a/src/train.py
+++ b/src/train.py
@@ -162,7 +162,7 @@ def train(cfg: DictConfig) -> Tuple[dict, dict]:
             if best_ckpt_path == "":
                 log.warning("Best ckpt not found! Using current weights for saving...")
             else:
-                model.load_from_checkpoint(best_ckpt_path)
+                model = type(model).load_from_checkpoint(best_ckpt_path)
 
             log.info(f"Save model to {cfg.model_save_dir} [push_to_hub={cfg.push_to_hub}]")
             model.save_pretrained(save_directory=cfg.model_save_dir, push_to_hub=cfg.push_to_hub)


### PR DESCRIPTION
Before this PR, not the best model (according to the checkpoint callback) was saved when training finishes, but just the last checkpoint. This PR fixes this by correctly loading the best checkpoint into the model before saving it.

This PR also modifies the condition when a model is saved to **not** require `train=true`. This allows to save zero-shot variants of models e.g. to evaluate them with the same scripts as trained few-shot models etc. Model saving can still easily disabled by setting `model_save_dir=null`.