### PR TITLE
make test_train_eval() deterministic

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -35,6 +35,6 @@ def test_train_eval(tmp_path, cfg_train, cfg_eval):
     HydraConfig().set_config(cfg_eval)
     test_metric_dict, _ = evaluate(cfg_eval)
 
-    assert test_metric_dict["test/loss"] > 0.0
-    assert torch.isclose(train_metric_dict["test/loss"], test_metric_dict["test/loss"])
-    assert torch.isclose(train_metric_dict["test/f1"], test_metric_dict["test/f1"])
+    assert len(test_metric_dict) > 0
+    for k in test_metric_dict:
+        assert torch.isclose(train_metric_dict[k], test_metric_dict[k])


### PR DESCRIPTION
`test_train_eval()` occasionally fails because the test F1 remains zero. Now, we ensure reproducibility by setting the `seed` and `trainer.deterministic=True`. Furthermore, we just check that the test scores are the same as after training (and do not ensure that it is above zero).