### PR TITLE
load all models and taskmodules in main entry scripts

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -44,6 +44,8 @@ from pytorch_lightning import Trainer
 
 from src import utils
 from src.datamodules import PieDataModule
+from src.models import *  # noqa: F403
+from src.taskmodules import *  # noqa: F403
 
 log = utils.get_pylogger(__name__)
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -42,8 +42,8 @@ from omegaconf import DictConfig, OmegaConf
 from pytorch_ie import DatasetDict, Pipeline
 
 from src import utils
-from src.serializer.interface import DocumentSerializer
 from src.models import *  # noqa: F403
+from src.serializer.interface import DocumentSerializer
 from src.taskmodules import *  # noqa: F403
 
 log = utils.get_pylogger(__name__)

--- a/src/predict.py
+++ b/src/predict.py
@@ -43,6 +43,8 @@ from pytorch_ie import DatasetDict, Pipeline
 
 from src import utils
 from src.serializer.interface import DocumentSerializer
+from src.models import *  # noqa: F403
+from src.taskmodules import *  # noqa: F403
 
 log = utils.get_pylogger(__name__)
 

--- a/src/train.py
+++ b/src/train.py
@@ -47,6 +47,8 @@ from pytorch_lightning.loggers import Logger
 
 from src import utils
 from src.datamodules import PieDataModule
+from src.models import *  # noqa: F403
+from src.taskmodules import *  # noqa: F403
 
 log = utils.get_pylogger(__name__)
 


### PR DESCRIPTION
With this PR, everything from models and taskmodules is imported in the main entry scripts (train.py, evaluate.py, and predict.py) to register any user defined classes to make them work with Auto* classes.

This should fix #73.