### PR TITLE
fix hparams logging when using multiple loggers

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -159,7 +159,8 @@ def log_hyperparameters(object_dict: dict) -> None:
     hparams["model_save_dir"] = cfg.get("model_save_dir")
 
     # send hparams to all loggers
-    trainer.logger.log_hyperparams(hparams)
+    for logger in trainer.loggers:
+        logger.log_hyperparams(hparams)
 
 
 def get_metric_value(metric_dict: dict, metric_name: str) -> Optional[float]:


### PR DESCRIPTION
Integrate changes from https://github.com/ashleve/lightning-hydra-template/pull/479:

"This change make the `hparams` sent to all loggers. Before: The `hparams` will be only sent to the first logger if `many_loggers.yaml` is used, so the other logger only get a default empty Dict."