### PR TITLE
allow to write job result as markdown + save aggregated result (if multirun)

### DIFF
--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -11,6 +11,9 @@ defaults:
 callbacks:
   save_job_return:
     _target_: src.hydra_callbacks.SaveJobReturnValueCallback
+    filenames:
+      - job_return_value.json
+      - job_return_value.md
 
 # output directory, generated dynamically on each run
 run:

--- a/src/hydra_callbacks/save_job_return_value.py
+++ b/src/hydra_callbacks/save_job_return_value.py
@@ -1,10 +1,12 @@
 import json
 import logging
+import os
 import pickle
 from pathlib import Path
-from typing import Any, List
+from typing import Any, Dict, Generator, List, Tuple, Union
 
 import numpy as np
+import pandas as pd
 import torch
 from hydra.core.utils import JobReturn
 from hydra.experimental.callback import Callback
@@ -66,50 +68,112 @@ def list_of_dicts_to_dict_of_lists_recursive(list_of_dicts):
         return list_of_dicts
 
 
+def _flatten_dict_gen(d, parent_key: Tuple[str, ...] = ()) -> Generator:
+    for k, v in d.items():
+        new_key = parent_key + (k,)
+        if isinstance(v, dict):
+            yield from dict(_flatten_dict_gen(v, new_key)).items()
+        else:
+            yield new_key, v
+
+
+def flatten_dict(d: Dict[str, Any]) -> Dict[Tuple[str, ...], Any]:
+    return dict(_flatten_dict_gen(d))
+
+
+def unflatten_dict(d: Dict[Tuple[str, ...], Any]) -> Union[Dict[str, Any], Any]:
+    """Unflattens a dictionary with nested keys.
+
+    Example:
+        >>> d = {("a", "b", "c"): 1, ("a", "b", "d"): 2, ("a", "e"): 3}
+        >>> unflatten_dict(d)
+        {'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}
+    """
+    result: Dict[str, Any] = {}
+    for k, v in d.items():
+        if len(k) == 0:
+            if len(result) > 1:
+                raise ValueError("Cannot unflatten dictionary with multiple root keys.")
+            return v
+        current = result
+        for key in k[:-1]:
+            current = current.setdefault(key, {})
+        current[k[-1]] = v
+    return result
+
+
 class SaveJobReturnValueCallback(Callback):
     """Save the job return-value in ${output_dir}/{job_return_value_filename}.
 
-    This also works for multi-runs (sweeps).
+    This also works for multi-runs (e.g. sweeps for hyperparameter search). In this case, the result will be saved
+    additionally in a common file in the multi-run log directory. If integrate_multirun_result=True, the
+    job return-values are also aggregated (e.g. mean, min, max) and saved in another file.
 
     params:
     -------
-    job_return_value_filename: str
-        The filename of the job return-value (default: "job_return_value.json"). If it ends with ".json",
+    filenames: str or List[str] (default: "job_return_value.json")
+        The filename(s) of the file(s) to save the job return-value to. If it ends with ".json",
         the return-value will be saved as a json file. If it ends with ".pkl", the return-value will be
-        saved as a pickle file.
-    merge_multirun_result: bool (default: True)
+        saved as a pickle file, if it ends with ".md", the return-value will be saved as a markdown file.
+    integrate_multirun_result: bool (default: True)
         If True, the job return-values of all jobs from a multi-run will be rearranged into a dict of lists (maybe
         nested), where the keys are the keys of the job return-values and the values are lists of the corresponding
         values of all jobs. This is useful if you want to access specific values of all jobs in a multi-run all at once.
+        Also, aggregated values (e.g. mean, min, max) are created for all numeric values and saved in another file.
     """
 
     def __init__(
         self,
-        job_return_value_filename: str = "job_return_value.json",
-        merge_multirun_result: bool = True,
+        filenames: Union[str, List[str]] = "job_return_value.json",
+        integrate_multirun_result: bool = True,
     ) -> None:
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
-        self.job_return_value_filename = job_return_value_filename
-        self.merge_multirun_result = merge_multirun_result
+        self.filenames = [filenames] if isinstance(filenames, str) else filenames
+        self.integrate_multirun_result = integrate_multirun_result
         self.job_returns: List[JobReturn] = []
 
     def on_job_end(self, config: DictConfig, job_return: JobReturn, **kwargs: Any) -> None:
         self.job_returns.append(job_return)
         output_dir = Path(config.hydra.runtime.output_dir)  # / Path(config.hydra.output_subdir)
-        filename = self.job_return_value_filename
-        self._save(obj=job_return.return_value, filename=filename, output_dir=output_dir)
-        self.log.info(f"Saving job_return in {output_dir / filename}")
+        for filename in self.filenames:
+            self._save(obj=job_return.return_value, filename=filename, output_dir=output_dir)
 
     def on_multirun_end(self, config: DictConfig, **kwargs: Any) -> None:
-        filename = self.job_return_value_filename
+        if self.integrate_multirun_result:
+            # rearrange the job return-values of all jobs from a multi-run into a dict of lists (maybe nested),
+            obj = list_of_dicts_to_dict_of_lists_recursive(
+                [jr.return_value for jr in self.job_returns]
+            )
+            # also create an aggregated result
+            obj_flat = flatten_dict(obj)
+            obj_described = pd.DataFrame(obj_flat).describe()
+            # add the aggregation keys (e.g. mean, min, ...) as most inner keys and convert back to dict
+            obj_flat_aggregated = obj_described.T.stack().to_dict()
+            # unflatten because _save() works better with nested dicts
+            obj_aggregated = unflatten_dict(obj_flat_aggregated)
+        else:
+            # create a dict of the job return-values of all jobs from a multi-run
+            # (_save() works better with nested dicts)
+            obj = {i: jr.return_value for i, jr in enumerate(self.job_returns)}
+            obj_aggregated = None
         output_dir = Path(config.hydra.sweep.dir)
-        obj = [jr.return_value for jr in self.job_returns]
-        if self.merge_multirun_result:
-            obj = list_of_dicts_to_dict_of_lists_recursive(obj)
-        self._save(obj=obj, filename=filename, output_dir=output_dir)
-        self.log.info(f"Saving job_return in {output_dir / filename}")
+        for filename in self.filenames:
+            self._save(
+                obj=obj,
+                filename=filename,
+                output_dir=output_dir,
+                multi_run_result=self.integrate_multirun_result,
+            )
+            # if available, also save the aggregated result
+            if obj_aggregated is not None:
+                file_base_name, ext = os.path.splitext(filename)
+                filename_aggregated = f"{file_base_name}.aggregated{ext}"
+                self._save(obj=obj_aggregated, filename=filename_aggregated, output_dir=output_dir)
 
-    def _save(self, obj: Any, filename: str, output_dir: Path) -> None:
+    def _save(
+        self, obj: Any, filename: str, output_dir: Path, multi_run_result: bool = False
+    ) -> None:
+        self.log.info(f"Saving job_return in {output_dir / filename}")
         output_dir.mkdir(parents=True, exist_ok=True)
         assert output_dir is not None
         if filename.endswith(".pkl"):
@@ -120,5 +184,29 @@ class SaveJobReturnValueCallback(Callback):
             obj_py = to_py_obj(obj)
             with open(str(output_dir / filename), "w") as file:
                 json.dump(obj_py, file, indent=2)
+        elif filename.endswith(".md"):
+            # Convert PyTorch tensors and numpy arrays to native python types
+            obj_py = to_py_obj(obj)
+            obj_py_flat = flatten_dict(obj_py)
+
+            if multi_run_result:
+                # In the case of multi-run, we expect to have multiple values for each key.
+                # We therefore just convert the dict to a pandas DataFrame.
+                result = pd.DataFrame(obj_py_flat)
+            else:
+                # In the case of a single job, we expect to have only one value for each key.
+                # We therefore convert the dict to a pandas Series and ...
+                series = pd.Series(obj_py_flat)
+                if len(series.index.levels) > 1:
+                    # ... if the Series has multiple index levels, we create a DataFrame by unstacking the last level.
+                    result = series.unstack(-1)
+                else:
+                    # ... otherwise we just unpack the one-entry index values and save the resulting Series.
+                    series.index = series.index.get_level_values(0)
+                    result = series
+
+            with open(str(output_dir / filename), "w") as file:
+                file.write(result.to_markdown())
+
         else:
             raise ValueError("Unknown file extension")


### PR DESCRIPTION
This PR implements the following changes of the `SaveJobReturnValueCallback`:
- rename parameter `merge_multirun_result` to `integrate_multirun_result` and `job_return_value_filename` to `filenames`
- allow multiple file names to save the data in multiple formats at once
- save aggregated results (e.g. mean, max, min) if `integrate_multirun_result=True`

This also modifies the respective config (`hydra/default.yaml`) to save the result in `json` and `markdown` per default.

This implements #114.