### PR TITLE
align input and output paths

### DIFF
--- a/configs/dataset/from_serialized_documents.yaml
+++ b/configs/dataset/from_serialized_documents.yaml
@@ -1,4 +1,7 @@
 _target_: pytorch_ie.DatasetDict.from_json
 document_type: ??? # src.taskmodules.extractive_question_answering.ExtractiveQADocument
-data_files:
-  test: ${document_path}
+# either define data_files ...
+# data_files:
+#   test: path/to/documents.jsonl
+# ... or a data_dir
+# data_dir: path/to/directory/with/splits/as/subfolders/containing/documents.jsonl

--- a/configs/evaluate_documents.yaml
+++ b/configs/evaluate_documents.yaml
@@ -17,9 +17,6 @@ seed: null
 
 name: "default"
 
-# path to the json file containing the documents to evaluate. May be used in the dataset config
-# document_path: ???
-
 # If defined, evaluate only these splits of the dataset. Note, that per default the data from the
 # document_path gets loaded to the "test" split of the dataset when using
 # dataset=from_serialized_documents (see the respective dataset config for details).

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -31,8 +31,13 @@ ckpt_path: null
 # which split from the loaded dataset will be used
 dataset_split: test
 
+## enable this to predict on the first GPU with batch size 32
+# pipeline:
+#   device: 0
+#   batch_size: 32
+
 # predefined path that can be used as output path for the serializer
-prediction_save_dir: ${paths.save_dir}/predictions/${name}/${dataset_split}/${now:%Y-%m-%d_%H-%M-%S}
+prediction_save_dir: ${paths.save_dir}/predictions/${name}/${now:%Y-%m-%d_%H-%M-%S}
 
 # if set, the final config including resolved paths etc. will be written to this location
 config_out_path: ${prediction_save_dir}/config.yaml

--- a/configs/serializer/json.yaml
+++ b/configs/serializer/json.yaml
@@ -1,2 +1,2 @@
 _target_: src.serializer.JsonSerializer
-path: ${prediction_save_dir}/documents.jsonl
+path: ${prediction_save_dir}/${dataset_split}/documents.jsonl

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -16,7 +16,9 @@ def test_predict_cpu(tmp_path, cfg_predict):
     HydraConfig().set_config(cfg_predict)
     predict(cfg_predict)
 
-    assert path.exists(path.join(cfg_predict.prediction_save_dir, "documents.jsonl"))
+    assert path.exists(
+        path.join(cfg_predict.prediction_save_dir, cfg_predict.dataset_split, "documents.jsonl")
+    )
     assert path.exists(path.join(cfg_predict.prediction_save_dir, "config.yaml"))
 
 
@@ -28,7 +30,9 @@ def test_predict_cpu_fast_dev_run(tmp_path, cfg_predict):
     HydraConfig().set_config(cfg_predict)
     predict(cfg_predict)
 
-    assert path.exists(path.join(cfg_predict.prediction_save_dir, "documents.jsonl"))
+    assert path.exists(
+        path.join(cfg_predict.prediction_save_dir, cfg_predict.dataset_split, "documents.jsonl")
+    )
     assert path.exists(path.join(cfg_predict.prediction_save_dir, "config.yaml"))
 
 
@@ -42,7 +46,9 @@ def test_predict_gpu(tmp_path, cfg_predict):
     HydraConfig().set_config(cfg_predict)
     predict(cfg_predict)
 
-    assert path.exists(path.join(cfg_predict.prediction_save_dir, "documents.jsonl"))
+    assert path.exists(
+        path.join(cfg_predict.prediction_save_dir, cfg_predict.dataset_split, "documents.jsonl")
+    )
     assert path.exists(path.join(cfg_predict.prediction_save_dir, "config.yaml"))
 
 
@@ -83,5 +89,7 @@ def test_serialize_only(tmp_path, cfg_predict):
     HydraConfig().set_config(cfg_predict)
     predict(cfg_predict)
 
-    assert path.exists(path.join(cfg_predict.prediction_save_dir, "documents.jsonl"))
+    assert path.exists(
+        path.join(cfg_predict.prediction_save_dir, cfg_predict.dataset_split, "documents.jsonl")
+    )
     assert path.exists(path.join(cfg_predict.prediction_save_dir, "config.yaml"))


### PR DESCRIPTION
This PR implements the following changes:
 - use the `dataset_split` parameter in the `serializer.path` instead of in the `prediction_save_dir`
 - do not predefine the `data_files` parameter in the `from_serialized_documents` dataset config (to also allow using `data_dir`)