### PR TITLE
Replace sys args with values from files

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -125,5 +125,6 @@ def main(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
+    utils.replace_sys_args_with_values_from_files()
     utils.prepare_omegaconf()
     main()

--- a/src/evaluate_documents.py
+++ b/src/evaluate_documents.py
@@ -106,5 +106,6 @@ def main(cfg: DictConfig) -> Any:
 
 
 if __name__ == "__main__":
+    utils.replace_sys_args_with_values_from_files()
     utils.prepare_omegaconf()
     main()

--- a/src/predict.py
+++ b/src/predict.py
@@ -132,5 +132,6 @@ def main(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
+    utils.replace_sys_args_with_values_from_files()
     utils.prepare_omegaconf()
     main()

--- a/src/train.py
+++ b/src/train.py
@@ -229,5 +229,6 @@ def main(cfg: DictConfig) -> Optional[float]:
 
 
 if __name__ == "__main__":
+    utils.replace_sys_args_with_values_from_files()
     utils.prepare_omegaconf()
     main()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,4 @@
 from .config_utils import execute_pipeline, instantiate_dict_entries, prepare_omegaconf
 from .logging_utils import close_loggers, get_pylogger, log_hyperparameters
 from .rich_utils import enforce_tags, print_config_tree
-from .task_utils import extras, save_file, task_wrapper
+from .task_utils import extras, replace_sys_args_with_values_from_files, save_file, task_wrapper


### PR DESCRIPTION
This PR implements `replace_sys_args_with_values_from_files()` and calls it at the beginning of each hydra based main entry scripts. This allows to replace command line arguments with the content of json files. The functionality is triggered by either using `LOAD_ARG:` or `LOAD_MULTI_ARG`. In the latter case, the value is expected to be a list that will get unwrapped (`[1,2,3]` becomes `1,2,3`) to be compatible with hydra `--multirun` functionality.  This is primarily developed to ease multirun experiments (train -> predict -> evaluate). 

Example call:

```
# This will set the value for `+dataset.data_files.test` to the content of the respective json at the nested key `serializer` / `path`.
python src/evaluate_documents.py \
metric.layer=entities \
dataset.document_type=src.document.types.TextDocumentWithLabeledEntitiesAndRelations \
+dataset.data_files.test=LOAD_MULTI_ARG:logs/prediction/multiruns/default/2023-08-21_16-14-22/job_return_value.json:serializer/path \
--multirun
```